### PR TITLE
Added support PHPUnit 6.x. Removed support PHPUnit < 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
-    - 5.6
     - 7.0
+    - 7.1
     - hhvm
 
 sudo: false
@@ -14,46 +12,16 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: PHPUNIT_VERSION="3.7.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.0.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.1.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.2.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.3.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.4.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.5.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.6.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.8.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="5.0.*"
-    - php: 5.6
-      env: PHPUNIT_VERSION="4.8.x-dev"
-    - php: 5.6
-      env: PHPUNIT_VERSION="5.0.x-dev"
-    - php: 5.6
-      env: PHPUNIT_VERSION="5.1.x-dev"
-    - php: 5.6
-      env: PHPUNIT_VERSION="5.2.x-dev"
     - php: 7.0
-      env: PHPUNIT_VERSION="6.0.x-dev"
+      env: PHPUNIT_VERSION="6.0.*"
     - php: 7.0
       env: PHPUNIT_VERSION="dev-master"
+    - php: 7.1
+      env: PHPUNIT_VERSION="6.0.*"
+    - php: 7.1
+      env: PHPUNIT_VERSION="dev-master"
   allow_failures:
-    - php: 7.0
     - php: hhvm
-    - env: PHPUNIT_VERSION="4.8.x-dev"
-    - env: PHPUNIT_VERSION="5.0.x-dev"
-    - env: PHPUNIT_VERSION="5.1.x-dev"
-    - env: PHPUNIT_VERSION="5.2.x-dev"
-    - env: PHPUNIT_VERSION="6.0.x-dev"
     - env: PHPUNIT_VERSION="dev-master"
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "munkie/phpunit-teamcity-testlistener",
     "description": "PHPUnit test listener for TeamCity CI Server",
     "require": {
-        "phpunit/phpunit": ">=3.7,<6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "require-dev": {
-        "codeception/aspect-mock": "~0.5",
+        "codeception/aspect-mock": "^2",
         "scrutinizer/ocular": "~1.0"
     },
     "license": "MIT",

--- a/tests/PHPUnit/TeamCity/Tests/Fixtures/DataProviderTest.php
+++ b/tests/PHPUnit/TeamCity/Tests/Fixtures/DataProviderTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPUnit\TeamCity\Tests\Fixtures;
 
-class DataProviderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DataProviderTest extends TestCase
 {
     /**
      * @dataProvider dataProviderWithKeys
@@ -22,6 +24,7 @@ class DataProviderTest extends \PHPUnit_Framework_TestCase
     public function testDuration()
     {
         usleep(2500000);
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/PHPUnit/TeamCity/Tests/Fixtures/FailingTest.php
+++ b/tests/PHPUnit/TeamCity/Tests/Fixtures/FailingTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPUnit\TeamCity\Tests\Fixtures;
 
-class FailingTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class FailingTest extends TestCase
 {
     public function testShouldFailSame()
     {

--- a/tests/PHPUnit/TeamCity/Tests/Fixtures/SubFolder/SubFolderTest.php
+++ b/tests/PHPUnit/TeamCity/Tests/Fixtures/SubFolder/SubFolderTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPUnit\TeamCity\Tests\Fixtures\SubFolder;
 
-class SubFolderTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SubFolderTest extends TestCase
 {
     public function testSubMethod()
     {


### PR DESCRIPTION
Hi!
I removed support phpunit v5 and lower, for simplify code. Because in phpunit v6 used namespaces and support phpunit v5 need double code.